### PR TITLE
Migrate json2xml and xml2json in favor of fast-xml-parser to avoid problem with newer Node.js versions

### DIFF
--- a/config/rgProperties.json
+++ b/config/rgProperties.json
@@ -10,7 +10,7 @@
         "LIVE_HOST_16": "gateway-16.rocketgate.com",
         "LIVE_HOST_17": "gateway-17.rocketgate.com",
         "TEST_HOST": "dev-gateway.rocketgate.com",
-        "VERSION_NUMBER": "K2.5"
+        "VERSION_NUMBER": "K2.6"
     },
     "responseSettings": {
         "VERSION_INDICATOR": "version",

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,18 +1,31 @@
-var xml2json = require('xml2json'),
-    json2xml = require("json2xml");
+const { XMLParser, XMLBuilder } = require('fast-xml-parser');
+
+const parser = new XMLParser({
+    attributeNamePrefix: "",
+    textNodeName: "$t",
+    parseTagValue: false,
+    ignoreDeclaration: true,
+    ignoreAttributes: false,
+});
+
+const builder = new XMLBuilder({
+    ignoreAttributes: false,
+    attributeNamePrefix: "$",
+    textNodeName: "$t",
+});
 
 var exports = module.exports = {
-
     toXML: function (params, callback) {
         try {
-            callback(null, json2xml({ gatewayRequest: params }, { header: true }));
+            const xml = builder.build({ '?xml': { '$version': '1.0', '$encoding': 'UTF-8' }, gatewayRequest: params });
+            callback(null, xml);
         } catch (err) {
             callback(err);
         }
     },
     fromXML: function (xmlDocument, callback) {
         try {
-            callback(null, JSON.parse(xml2json.toJson(xmlDocument)).gatewayResponse);
+            callback(null, parser.parse(xmlDocument).gatewayResponse);
         } catch (err) {
             callback(err);
         }

--- a/package.json
+++ b/package.json
@@ -24,12 +24,11 @@
     ],
     "dependencies": {
         "async": "2.1.x",
+        "fast-xml-parser": "5.3.x",
         "is_js": "0.9.x",
-        "json2xml": "0.1.x",
         "moment": "2.15.x",
         "request": "2.76.x",
-        "urlencode": "1.1.x",
-        "xml2json": "0.10.x"
+        "urlencode": "1.1.x"
     },
     "devDependencies": {
         "eslint": "^3.17.1",


### PR DESCRIPTION
## Context 

The libraries `json2xml` and `xml2json` are not maintained, and the `xml2json` doesn't work with newer Node.js versions.

```
expat/build/Release/node_expat.node: invalid ELF header
    at Module._extensions..node (node:internal/modules/cjs/loader:1454:18)
    at Module.load (node:internal/modules/cjs/loader:1208:32)
    at Module._load (node:internal/modules/cjs/loader:1024:12)
    at Module.require (node:internal/modules/cjs/loader:1233:19)
    at Module.patchedRequire (.../node_modules/.pnpm/require-in-the-middle@7.5.2/node_modules/require-in-the-middle/index.js:256:27)
    at Hook._require.Module.require (.../node_modules/.pnpm/require-in-the-middle@7.5.2/node_modules/require-in-the-middle/index.js:181:27)
    at require (node:internal/modules/helpers:179:18)
    at bindings (.../node_modules/.pnpm/bindings@1.5.0/node_modules/bindings/bindings.js:112:48)
    at Object.<anonymous> (.../node_modules/.pnpm/node-expat@2.4.1/node_modules/node-expat/lib/node-expat.js:4:34)
    at Module._compile (node:internal/modules/cjs/loader:1358:14) {
  code: 'ERR_DLOPEN_FAILED'
}

Node.js v20.15.1
```

## Changes

- I just changed the utils functions, where it imports and uses the removed dependencies, to use the `fast-xml-parser`.
- I also set the `fast-xml-parser` options to generate the same output for both cases.
- Also, I removed from the package.json the `json2xml` and `xml2json`, and added the `fast-xml-parser`